### PR TITLE
『[上下左右内外]側[にへが]』が誤判定しないように

### DIFF
--- a/dict/prh-basic.yml
+++ b/dict/prh-basic.yml
@@ -23,7 +23,7 @@ rules:
   - expected: すべて
     pattern: 全て
   - expected: そば$1
-    pattern: /側([にへが])/
+    pattern: /(?<![上下左右内外])側([にへが])/
   - expected: たくさん
     pattern: 沢山
   - expected: ただ


### PR DESCRIPTION
『上側に』『下側に』『左側に』『右側に』『内側に』『外側に』などが誤判定しないようにしました。