### PR TITLE
refactor: TypeScriptのtypeを追加

### DIFF
--- a/src/@type/@textlint/module-interop.d.ts
+++ b/src/@type/@textlint/module-interop.d.ts
@@ -1,0 +1,2 @@
+
+declare module "@textlint/module-interop";

--- a/src/@type/@textlint/require.d.ts
+++ b/src/@type/@textlint/require.d.ts
@@ -1,0 +1,1 @@
+declare function require(path: string): any;


### PR DESCRIPTION
## 関連URL

https://smarthr.atlassian.net/browse/SD-361

## 背景

`@textlint/module-interop`と`require`の型が未定義なので、
エディタ上でサジェストが表示されてしまうのでなんとかしたい。

## やったこと

`@textlint/module-interop`と`require`の型定義ファイルを暫定的に追加。

## 確認方法

エディタ上（VScode推奨）で型未定義のサジェストが表示されないこと。
