### PR TITLE
fix: require.d.tsの削除

### DIFF
--- a/src/@type/@textlint/require.d.ts
+++ b/src/@type/@textlint/require.d.ts
@@ -1,1 +1,0 @@
-declare function require(path: string): any;


### PR DESCRIPTION
## 背景

すみません、[これ](https://github.com/kufu/textlint-rule-preset-smarthr/pull/5)をマージすることで、requireが重複し、`Duplicate identifier`を引き起こしてました。
お手数をおかけしますが再度ご確認をお願いします:pray:

## 対応

型定義require.d.tsを削除しました。

## 確認方法

`yarn build`でエラーが起きないこと。
