### PR TITLE
Remove LINE from prh tech word

### DIFF
--- a/dict/prh-tech-word.yml
+++ b/dict/prh-tech-word.yml
@@ -356,8 +356,6 @@ rules:
     pattern: /\bKyotoCabinet\b/
   - expected: Kyoto Tycoon
     pattern: /\bKyotoTycoon\b|Tokyo *Tycoon/
-  - expected: LINE
-    pattern: /\bLINE\b/i
   - expected: LinkedIn
     pattern: /\bLinked In\b/
   - expected: LL


### PR DESCRIPTION
## 概要

prh-tech-word から `LINE` を削除した。

## 動機

TypeScriptなどのコードを解析する場合、文言以外の string も対象になるが、`line` は変数名で頻出するためコードが書き換えられてしまうため。

例: `FaChartLine` from SmartHR UI - Icon https://github.com/kufu/smarthr-ui/blob/master/src/components/Icon/Icon.tsx#L67