### PR TITLE
chore: renovateで依存度が強いパッケージをグループ化してconflictを抑える TEXTLINT-47

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,27 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>kufu/renovate-config"
-  ]
+  ],
+  "npm": {
+    "packageRules": [
+      {
+        "groupName": "textlint rules",
+        "matchPackageNames": [
+          "@textlint-rule/textlint-rule-no-unmatched-pair",
+          "@textlint/module-interop"
+        ],
+        "matchPackagePatterns": [
+          "^textlint-rule-*"
+        ]
+      },
+      {
+        "groupName": "textlint family",
+        "matchPackageNames": [
+          "@textlint/types",
+          "textlint-scripts",
+          "textlint-tester"
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## 関連リンク

- https://smarthr.atlassian.net/browse/TEXTLINT-47

## 課題・背景

- 互いに依存関係のあるライブラリアップデートのPRが個別に作られるとCI通らなかったりしてつらい
- そうでなくてもrule系が一気にアップデートきて、1つマージするたびにrebaseするのもつらい

## やったこと

- 互いに依存度が強いライブラリアップデートを1つのPRにまとめるようにした
    - textlint-rule-* のルール関連
    - textlint本体絡み

## やらなかったこと

🍐

## 動作確認

1. ✅ 以下コマンドで `renovate.json` がvalidなことを確認する
```sh
$ npx --package renovate -c 'renovate-config-validator'
```
