### PR TITLE
fix: branch protectionによってsemantic-releaseが失敗する問題を解決する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup NodeJS 14
         uses: actions/setup-node@v2
@@ -30,7 +31,6 @@ jobs:
 
       - name: Release
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
 
       - name: Release
         env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## 課題・背景

- semantic-release経由でrelease作業を実行しようとすると、branchへの権限不足でエラーが起きてしまう
  - ![CleanShot 2021-08-31 at 20 59 08](https://user-images.githubusercontent.com/4032232/131498687-9a71463a-a214-4f25-9410-93e6e6cd4fa4.png)
  - https://github.com/kufu/textlint-rule-preset-smarthr/runs/3472399376?check_suite_focus=true
- 最終的にこの設定で解決できそうなことを発見
  - https://github.com/semantic-release/semantic-release/blob/master/docs/recipes/github-actions.md#pushing-packagejson-changes-to-a-master-branch

<!--
e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
- 〇〇を〇〇したい
-->

## やったこと

- ~https://github.com/semantic-release/github/issues/175#issuecomment-757448750 を参照。~
  - ~Brunch Protectionがかかっている場合、自動生成される`GITHUB_TOKEN `ではなく、Personal Tokenとして発行したtokenを`GH_TOKEN`として設定すれば動作する...と言ったことが書いていた。~
  - これは個人のtokenを使うことになるため、望ましくなさそうということで却下
- `actions/checkout@v2`に対して`persist-credentials: false`の設定を追加した。
  - 参考記事
    - https://github.com/semantic-release/semantic-release/blob/master/docs/recipes/github-actions.md#pushing-packagejson-changes-to-a-master-branch 
    - https://github.com/semantic-release/git/issues/196#issuecomment-601310576

<!--
e.g.
- ルールの追加
-->

## やらなかったこと

<!--
e.g.
- 重複ルールの削除
-->

## 動作確認

### 正しいと判定される想定の文章

<!-- 
e.g.
ください。
-->

### 誤りと判定される想定の文章

<!-- 
e.g.
下さい。
-->
