### PR TITLE
fix: release actionにtokenを追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Release
         env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
## 課題・背景

https://github.com/kufu/textlint-rule-preset-smarthr/pull/96 でも設定不足でreleaseができなかったので、修正したい

<!--
e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
- 〇〇を〇〇したい
-->

## やったこと

- semantic-release用のgithubのtokenを設定してみた
  - 管理者のtokenを使ってるので、管理者変更の際はtokenを差し替えることが必須
  - 参考
    - https://github.com/semantic-release/github/issues/175#issuecomment-757448750
<!--
e.g.
- ルールの追加
-->

## やらなかったこと

<!--
e.g.
- 重複ルールの削除
-->

## 動作確認

### 正しいと判定される想定の文章

<!-- 
e.g.
ください。
-->

### 誤りと判定される想定の文章

<!-- 
e.g.
下さい。
-->
