### PR TITLE
chore: titleLintでrenovateを無視する設定を追加

### DIFF
--- a/.github/titleLint.yml
+++ b/.github/titleLint.yml
@@ -1,3 +1,3 @@
-regex:  (feat|fix|docs|chore|style|refactor|perf|test): .*
+regex:  (feat|fix|docs|chore|style|refactor|perf|test)(\(.*\))*: .*
 exclude_users:
   - renovate

--- a/.github/titleLint.yml
+++ b/.github/titleLint.yml
@@ -1,3 +1,3 @@
 regex:  (feat|fix|docs|chore|style|refactor|perf|test)(\(.*\))*: .*
-  exclude_users:
-    - otapo
+exclude_users:
+  - renovate

--- a/.github/titleLint.yml
+++ b/.github/titleLint.yml
@@ -1,3 +1,8 @@
-regex:  (feat|fix|docs|chore|style|refactor|perf|test)(\(.*\))*: .*
-exclude_users:
-  - otapo
+title-lint:
+  org: true
+  settings:
+      org:
+        final:
+          regex:  (feat|fix|docs|chore|style|refactor|perf|test)(\(.*\))*: .*
+          exclude_users:
+            - otapo

--- a/.github/titleLint.yml
+++ b/.github/titleLint.yml
@@ -1,8 +1,3 @@
-title-lint:
-  org: true
-  settings:
-      org:
-        final:
-          regex:  (feat|fix|docs|chore|style|refactor|perf|test)(\(.*\))*: .*
-          exclude_users:
-            - otapo
+regex:  (feat|fix|docs|chore|style|refactor|perf|test)(\(.*\))*: .*
+  exclude_users:
+    - otapo

--- a/.github/titleLint.yml
+++ b/.github/titleLint.yml
@@ -1,3 +1,3 @@
 regex:  (feat|fix|docs|chore|style|refactor|perf|test)(\(.*\))*: .*
 exclude_users:
-  - renovate
+  - otapo

--- a/.github/titleLint.yml
+++ b/.github/titleLint.yml
@@ -1,0 +1,3 @@
+regex:  (feat|fix|docs|chore|style|refactor|perf|test): .*
+exclude_users:
+  - renovate


### PR DESCRIPTION
## 課題・背景

<!--
e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
- 〇〇を〇〇したい
-->

https://smarthr.atlassian.net/browse/TEXTLINT-65

renovateのPRがtitleLintに怒られているので、renovateからのPRは無視したい。

## やったこと

<!--
e.g.
- ルールの追加
-->

- `.github/titleLint.yml` を追加
  - カッコ書きを許容するregexを指定
  - exclude_usersにrenovateを指定


## やらなかったこと

<!--
e.g.
- 重複ルールの削除
-->

🍐 

## 動作確認

renovateによる `chore(deps): hoge` のようなタイトルのPRが通ればOK

https://github.com/kufu/textlint-rule-preset-smarthr/pull/94
これとか