### PR TITLE
fix: hiragana-keishikimeishiのアップデートに対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ npm test
       "ja-no-redundant-expression": true,
       "no-mixed-zenkaku-and-hankaku-alphabet": true,
       "ja-keishikimeishi": {
-        "ditection_hou_kata" : false
+        "detection_hou_kata" : false
       },
       "ja-hiragana-fukushi": true,
       "ja-hiragana-hojodoushi": true,

--- a/example/.textlintrc
+++ b/example/.textlintrc
@@ -14,7 +14,7 @@
       "ja-no-redundant-expression": true,
       "no-mixed-zenkaku-and-hankaku-alphabet": true,
       "ja-keishikimeishi": {
-            "ditection_hou_kata" : false
+            "detection_hou_kata" : false
         },
       "ja-hiragana-fukushi": true,
       "ja-hiragana-hojodoushi": true,

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "textlint-rule-ja-hiragana-daimeishi": "^1.0.0",
     "textlint-rule-ja-hiragana-fukushi": "^1.3.0",
     "textlint-rule-ja-hiragana-hojodoushi": "^1.0.4",
-    "textlint-rule-ja-keishikimeishi": "^1.0.0",
+    "textlint-rule-ja-keishikimeishi": "^1.0.3",
     "textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana": "^2.2.0",
     "textlint-rule-ja-no-abusage": "^3.0.0",
     "textlint-rule-ja-no-mixed-period": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7457,10 +7457,10 @@ textlint-rule-ja-hiragana-hojodoushi@^1.0.4:
     kuromojin "^1.3.2"
     morpheme-match-all "^1.1.0"
 
-textlint-rule-ja-keishikimeishi@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/textlint-rule-ja-keishikimeishi/-/textlint-rule-ja-keishikimeishi-1.0.2.tgz#f867c91bf3aab6291caa07a5f223c5695ec2325e"
-  integrity sha512-7LVDiNz+1tf5LOL4MyYV6JdZgp1tym5tqONqIo0apQXua1aFVwugN7rwq7WlNSoXtka5HgDXXlg33ey5ip1XeA==
+textlint-rule-ja-keishikimeishi@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/textlint-rule-ja-keishikimeishi/-/textlint-rule-ja-keishikimeishi-1.0.3.tgz#000d9ffcfd2925cbd8dd7f04ab93ab8a69a9b095"
+  integrity sha512-XQwgjxipn2+qqKcZhAuXPvThnsHP+6AhvNjXiIaP86oDIgmGrThBRhjr9D9Pl8K3WgjIoxzruFmLLOJjlLESIA==
   dependencies:
     kuromojin "^2.1.1"
     morpheme-match-all "^1.1.0"


### PR DESCRIPTION
## 課題・背景

<!--
e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
- 〇〇を〇〇したい
-->

https://smarthr.atlassian.net/browse/TEXTLINT-68

## やったこと

<!--
e.g.
- ルールの追加
-->

hiragana-keishikimeishiのアップデートに合わせて、以下を変更
- README.md
- example/.textlintrc
- package.json
- yarn.lock

## やらなかったこと

<!--
e.g.
- 重複ルールの削除
-->