### PR TITLE
fix: 様→さま の正規表現が間違っていたので修正

### DIFF
--- a/dict/prh-basic.yml
+++ b/dict/prh-basic.yml
@@ -51,7 +51,16 @@ rules:
   - expected: したうえで
     pattern: した上で
   - expected: $1さま
-    pattern: /([従業員])様|([お客])様|([ユーザー])様|([皆])様/
+    pattern: /(従業員|お客|ユーザー|皆)様/
+    specs:
+      - from: 従業員様
+        to: 従業員さま
+      - from: お客様
+        to: お客さま
+      - from: ユーザー様
+        to: ユーザーさま
+      - from: 皆様
+        to: 皆さま
   - expected: 振り込み
     pattern: 振込
   - expected: 取り消し


### PR DESCRIPTION
## 課題・背景

「様」を「さま」に変換する正規表現が間違っていた。

<!--
e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
- 〇〇を〇〇したい
-->

## やったこと

- 正規表現の修正

<!--
e.g.
- ルールの追加
-->

## やらなかったこと

なし

<!--
e.g.
- 重複ルールの削除
-->

## 動作確認

### 正しいと判定される想定の文章

- お客様

<!-- 
e.g.
ください。
-->

### 誤りと判定される想定の文章

- お客さま

<!-- 
e.g.
下さい。
-->
