### PR TITLE
feat: npm test 実行時、定義中に含まれる spec の内容を検証

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
   },
   "scripts": {
     "example": "cd example && npm it",
-    "test": "textlint-scripts test",
+    "test:textlint-scripts": "textlint-scripts test",
+    "test:dict": "textlint --config test/.textlintrc README.md",
+    "test": "npm run test:dict && npm run test:textlint-scripts",
     "build": "textlint-scripts build",
     "prepublish": "npm run --if-present build",
     "release": "standard-version",

--- a/test/.textlintrc
+++ b/test/.textlintrc
@@ -1,0 +1,10 @@
+{
+  "rules": {
+    "prh": {
+      "rulePaths": [
+        "../dict/prh-basic.yml",
+        "../dict/prh-tech-word.yml",
+      ]
+    },
+  }
+}


### PR DESCRIPTION
## 課題・背景

テストを行う際には `dict/*.yml` の定義中に含まれる `specs` の中身も検証したい。

<!--
e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
- 〇〇を〇〇したい
-->

## やったこと

- `test:dict` というコマンドを追加した。中では textlint を実行しており、specs のチェックが行われる。
- これまでやっていた `test`  というコマンドは `test:textlint-scripts` に変更した。
- `test` では `test:textlint-scripts`、`test:dict` を逐次実行するようにした。

<!--
e.g.
- ルールの追加
-->

## やらなかったこと

- `test` を呼び出した際、`test:textlint-scripts`、`test:dict` を並列実行することも検討したが、1〜3秒くらいしか実行時間が短縮できなかったのでやめた。


<!--
e.g.
- 重複ルールの削除
-->

## 動作確認

- `npm test` （あるいは `npm run test:dict`）が実行でき、正常終了すること
- `dict/prh-basic.yml` の定義に適当な specs を追加し、`npm test` （あるいは `npm run test:dict`）を実行すると失敗すること