### PR TITLE
chore: プルリクエストタイトルのlintを追加

### DIFF
--- a/.github/workflows/titleCheck.yml
+++ b/.github/workflows/titleCheck.yml
@@ -1,0 +1,19 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  conventional_commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check title
+        run: |
+          regex="^(feat|fix|docs|chore|style|refactor|perf|test)!?(\([^\)]+\))?:[[:space:]].+"
+          if [[ "${{ github.event.pull_request.title }}" =~ $regex ]]; then
+              echo OK
+          else
+              echo "::error::Pull Request のタイトルが Conventional Commits 形式にマッチしません"
+              exit 1
+          fi


### PR DESCRIPTION
## 課題・背景

- `standard-version`で正しくアップデートさせるため、PRタイトルのlintを実行したい
<!--
e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
- 〇〇を〇〇したい
-->

## やったこと

- Github ActionにPR Titleのlintを実行する処理を追加
  - https://github.com/kufu/smarthr-ui/pull/1925を参考としています。
<!--
e.g.
- ルールの追加
-->

## やらなかったこと

<!--
e.g.
- 重複ルールの削除
-->

## 動作確認

### 正しいと判定される想定の文章

<!-- 
e.g.
ください。
-->

### 誤りと判定される想定の文章

<!-- 
e.g.
下さい。
-->
