### PR TITLE
fix: add dict directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "main": "lib/index.js",
   "files": [
     "lib",
-    "src"
+    "src",
+    "dict"
   ],
   "homepage": "https://github.com/kufu/textlint-rule-preset-smarthr#readme",
   "repository": {


### PR DESCRIPTION
## 課題・背景

<!--
e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
- 〇〇を〇〇したい
-->
follow up https://github.com/kufu/textlint-rule-preset-smarthr/pull/142
dict配下のファイルがpackage対象外になっていたため、publishされたpackage内部にymlファイルが存在しない状態になっている

## やったこと

<!--
e.g.
- ルールの追加
-->
dictをpackageの対象に含めた