### PR TITLE
fix: 「行なわれる」を検知できるようにする

### DIFF
--- a/dict/prh-idiomatic-usage.yml
+++ b/dict/prh-idiomatic-usage.yml
@@ -236,7 +236,7 @@ rules:
       - 差戻し
   - expected: 行な$1
     pattern:
-      - /行([いうえ])/
+      - /行([いうえわ])/
     prh: 「行なう」を使用する
     specs:
       - from: 行い
@@ -245,6 +245,8 @@ rules:
         to: 行なう
       - from: 行え
         to: 行なえ
+      - from: 行わ
+        to: 行なわ
   - expected: 何卒
     pattern:
       - 何とぞ
@@ -481,7 +483,7 @@ rules:
         to: 再読み込み
   - expected: 行な$1
     pattern:
-      - /おこな([いうえ])/
+      - /おこな([いうえわ])/
     prh: 「行なう」を使用する
     specs:
       - from: おこない
@@ -490,3 +492,5 @@ rules:
         to: 行なう
       - from: おこなえ
         to: 行なえ
+      - from: おこなわ
+        to: 行なわ


### PR DESCRIPTION
## 課題・背景

meyasu で `textlint-rule-preset-smarthr` の1.13.2 対応で「行う」を「行なう」に修正している際に、「行なわれる」が検知できていないことに気づきました。

https://github.com/kufu/meyasu/pull/2384#discussion_r879328266
該当の文言
- ` まだ回答依頼は行われていません。 `

もともとのルール追加は以下のPRで行なわれていそうです
- https://github.com/kufu/textlint-rule-preset-smarthr/pull/194


<!--
e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
- 〇〇を〇〇したい
-->

## やったこと

「行われる」「おこなわれる」が検知され、「行なわれる」に修正されるようにルールを修正しました。

<!--
e.g.
- ルールの追加
-->

## やらなかったこと

<!--
e.g.
- 重複ルールの削除
-->

## 動作確認

### 正しいと判定される想定の文章

- まだ回答依頼は**行なわ**れていません。

<!-- 
e.g.
ください。
-->

### 誤りと判定される想定の文章

- まだ回答依頼は**おこなわ**れていません。
- まだ回答依頼は**行わ**れていません。

<!-- 
e.g.
下さい。
-->
