### PR TITLE
feat: ja-keishikimeishiのバージョン1.0.4に対応＆オプション追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ npm test
       "ja-no-redundant-expression": true,
       "no-mixed-zenkaku-and-hankaku-alphabet": true,
       "ja-keishikimeishi": {
-        "detection_hou_kata" : false
+        "detection_hou_kata" : false,
+        "detection_ue" : false
       },
       "ja-hiragana-fukushi": true,
       "ja-hiragana-hojodoushi": true,

--- a/example/.textlintrc
+++ b/example/.textlintrc
@@ -14,7 +14,8 @@
       "ja-no-redundant-expression": true,
       "no-mixed-zenkaku-and-hankaku-alphabet": true,
       "ja-keishikimeishi": {
-            "detection_hou_kata" : false
+            "detection_hou_kata" : false,
+            "detection_ue" : false
         },
       "ja-hiragana-fukushi": true,
       "ja-hiragana-hojodoushi": true,

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "textlint-rule-ja-hiragana-daimeishi": "^1.0.0",
     "textlint-rule-ja-hiragana-fukushi": "^1.3.0",
     "textlint-rule-ja-hiragana-hojodoushi": "^1.0.4",
-    "textlint-rule-ja-keishikimeishi": "^1.0.3",
+    "textlint-rule-ja-keishikimeishi": "^1.0.4",
     "textlint-rule-ja-nakaguro-or-halfwidth-space-between-katakana": "^2.2.0",
     "textlint-rule-ja-no-abusage": "^3.0.0",
     "textlint-rule-ja-no-mixed-period": "^2.1.1",


### PR DESCRIPTION
## 課題・背景

ja-keishikimeishiが1.0.4にバージョンアップし、「上（うえ）」の判定をフラグで制御できるようになったので、追従したい。

また、デフォルトは `false` にしておきたい。

<!--
e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
- 〇〇を〇〇したい
-->

## やったこと

- package.json の更新
- .textlintrc の更新
- README.md の更新

<!--
e.g.
- ルールの追加
-->

## やらなかったこと

<!--
e.g.
- 重複ルールの削除
-->

## 動作確認

### 正しいと判定される想定の文章

確認のうえ、作業します。

<!-- 
e.g.
ください。
-->

### 誤りと判定される想定の文章

確認の上、作業します。

<!-- 
e.g.
下さい。
-->
