### PR TITLE
fix: 「ウェブ→Web」のルールを削除

### DIFF
--- a/dict/prh-tech-word.yml
+++ b/dict/prh-tech-word.yml
@@ -2,10 +2,6 @@
 rules:
   - expected: Twitter
     pattern: /ツイッター/
-  - expected: Web
-    pattern:
-      - ウェブ
-      - ウェッブ
   - expected: ソフトウェア
     pattern: /ソフトウエア/
   - expected: スマートフォン


### PR DESCRIPTION
## 課題・背景

ガイドラインで[「ウェブ」はカタカナで表記する](https://smarthr.design/products/contents/idiomatic-usage/usage/#rec8ZIzDZQ47CFM5l-0)と決めたが、Web表記を正とするルールが残っていたので削除したい。

## やったこと

`prh-tech-word.yml` から該当部分を削除

<!--
e.g.
- ルールの追加
-->

## やらなかったこと

その他の変更
<!--
e.g.
- 重複ルールの削除
-->

## 動作確認

### 正しいと判定される想定の文章

ウェブサイト

<!-- 
e.g.
ください。
-->

### 誤りと判定される想定の文章

Webサイト

<!-- 
e.g.
下さい。
-->
