### PR TITLE
fix: 「ユーザビリティ」の誤検知を修正

### DIFF
--- a/dict/prh-tech-word.yml
+++ b/dict/prh-tech-word.yml
@@ -9,7 +9,7 @@ rules:
   - expected: マスター$1
     pattern: /マスタ([^ー])/
   - expected: ユーザー$1
-    pattern: /ユーザ([^ー])/
+    pattern: /ユーザ([^(ー|ビリティ)])/
   - expected: ユーザビリティ
     pattern: /ユーザービリティ?/
   - expected: フィルター$1


### PR DESCRIPTION
## 課題・背景

「ユーザビリティ」が「ユーザー→ユーザー」のルールに誤検知されているので、修正したい。

<!--
e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
- 〇〇を〇〇したい
-->

## やったこと

`prh-tech-word.yml`のルールを修正。

<!--
e.g.
- ルールの追加
-->

## やらなかったこと

<!--
e.g.
- 重複ルールの削除
-->

## 動作確認

### 正しいと判定される想定の文章

<!-- 
e.g.
ください。
-->

### 誤りと判定される想定の文章

<!-- 
e.g.
下さい。
-->
