### PR TITLE
fix: デザインシステム内の誤検知を解消

### DIFF
--- a/dict/prh-idiomatic-usage.yml
+++ b/dict/prh-idiomatic-usage.yml
@@ -75,7 +75,7 @@ rules:
         to: すべて
   - expected: そば$1
     pattern:
-      - /(?<![上下左右内外])側([にへが])/
+      - /(?<![々〇〻\u3400-\u9FFF\uF900-\uFAFF]|[\uD840-\uD87F][\uDC00-\uDFFF])側([にへが])/
     prh: >-
       平仮名にしたほうが読みやすい漢字は平仮名にする
       https://smarthr.design/products/contents/writing-style/

--- a/dict/prh-tech-word.yml
+++ b/dict/prh-tech-word.yml
@@ -9,7 +9,7 @@ rules:
   - expected: マスター$1
     pattern: /マスタ([^ー])/
   - expected: ユーザー$1
-    pattern: /ユーザ([^ー])/
+    pattern: /ユーザ([^(ー|ビリティ)])/
   - expected: ユーザビリティ
     pattern: /ユーザービリティ?/
   - expected: フィルター$1

--- a/dict/prh-tech-word.yml
+++ b/dict/prh-tech-word.yml
@@ -9,11 +9,11 @@ rules:
   - expected: マスター$1
     pattern: /マスタ([^ー])/
   - expected: ユーザー$1
-    pattern: /ユーザ([^(ー|ビリティ)])/
+    pattern: /ユーザ((?!ー|ビリティ))/
   - expected: ユーザビリティ
     pattern: /ユーザービリティ?/
   - expected: フィルター$1
-    pattern: /フィルタ([^(ー|リング)])/
+    pattern: /フィルタ((?!ー|リング))/
   - expected: ナンバー$1
     pattern: /ナンバ([^ー])/
   - expected: メンバー$1

--- a/dict/prh-tech-word.yml
+++ b/dict/prh-tech-word.yml
@@ -9,11 +9,11 @@ rules:
   - expected: マスター$1
     pattern: /マスタ([^ー])/
   - expected: ユーザー$1
-    pattern: /ユーザ((?!ー|ビリティ))/
+    pattern: /ユーザ(?!(ー|ビリティ))/
   - expected: ユーザビリティ
     pattern: /ユーザービリティ?/
   - expected: フィルター$1
-    pattern: /フィルタ((?!ー|リング))/
+    pattern: /フィルタ(?!(ー|リング))/
   - expected: ナンバー$1
     pattern: /ナンバ([^ー])/
   - expected: メンバー$1

--- a/dict/prh-tech-word.yml
+++ b/dict/prh-tech-word.yml
@@ -13,7 +13,7 @@ rules:
   - expected: ユーザビリティ
     pattern: /ユーザービリティ?/
   - expected: フィルター$1
-    pattern: /フィルタ([^ー])/
+    pattern: /フィルタ([^(ー|リング)])/
   - expected: ナンバー$1
     pattern: /ナンバ([^ー])/
   - expected: メンバー$1


### PR DESCRIPTION
## 課題・背景

デザインシステム内で、textlintの誤検知が理由でルールを無視せざるを得ない箇所があったため、ルールを修正したい。
<!--
e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
- 〇〇を〇〇したい
-->

## やったこと

- ユーザビリティ→ユーザービリティ の誤検知を修正
  - 「ユーザ」の後が「ビリティ」の場合は検知しない
- フィルタリング→フィルターリング の誤検知を修正
  - 「フィルタ」の後が「リング」の場合は検知しない
- 利用者側、依頼側→利用者そば、依頼そばの誤検知を修正
  - 「側」の前が漢字の場合は検知しない

<!--
e.g.
- ルールの追加
-->

## やらなかったこと

<!--
e.g.
- 重複ルールの削除
-->

## 動作確認

### 正しいと判定される想定の文章

<!-- 
e.g.
ください。
-->

### 誤りと判定される想定の文章

<!-- 
e.g.
下さい。
-->
