### PR TITLE
fix: 副詞の誤検知を修正

### DIFF
--- a/dict/fukushi.yml
+++ b/dict/fukushi.yml
@@ -113,21 +113,6 @@ dict:
         reading: "アラカタ"
         pronunciation: "アラカタ"
   -
-    expected: あらためて
-    extensions: {}
-    tokens:
-      -
-        surface_form: "改めて"
-        pos: "副詞"
-        pos_detail_1: "一般"
-        pos_detail_2: "*"
-        pos_detail_3: "*"
-        conjugated_type: "*"
-        conjugated_form: "*"
-        basic_form: "改めて"
-        reading: "アラタメテ"
-        pronunciation: "アラタメテ"
-  -
     expected: いかに
     extensions: {}
     tokens:

--- a/dict/fukushi.yml
+++ b/dict/fukushi.yml
@@ -1021,12 +1021,6 @@ dict:
         reading: "モチロン"
         pronunciation: "モチロン"
   -
-    expected: もっとも
-    tokens:
-      -
-        surface_form: "最も"
-        pos: "副詞"
-  -
     expected: もともと
     extensions: {}
     tokens:


### PR DESCRIPTION
## 課題・背景

「最も」が「もっとも」に、「改めて」が「あらためて」に、ガイドラインに反する形で誤検知されるので、修正したい。
<!--
e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
- 〇〇を〇〇したい
-->

## やったこと

`fukushi.yml`から「もっとも」と「あらためて」に関するルールを削除した。

<!--
e.g.
- ルールの追加
-->

## やらなかったこと

<!--
e.g.
- 重複ルールの削除
-->

## 動作確認

### 正しいと判定される想定の文章

- 最も
- 改めて

<!-- 
e.g.
ください。
-->

### 誤りと判定される想定の文章

- もっとも
- あらためて

<!-- 
e.g.
下さい。
-->
