### PR TITLE
fix: 101件以上のレコードを取得できるように修正

### DIFF
--- a/scripts/export-airtable-rules.ts
+++ b/scripts/export-airtable-rules.ts
@@ -23,64 +23,67 @@ Airtable.configure({
 const baseId = process.env.AIRTABLE_BASE_ID ? process.env.AIRTABLE_BASE_ID : ''
 const base = Airtable.base(baseId)
 
-base('用字用語：一覧')
-  .select({
-    view: 'textlint用',
-  })
-  .firstPage((err: any, records) => {
-    if (err) {
-      console.error(err)
-      return
-    }
+const main = async () => {
+  let records;
+  try {
+    records = await base('用字用語：一覧').select({
+      view: 'textlint用'
+    }).all();
+  } catch (error){
+    console.log(error);
+    return;
+  };
 
-    if (records) {
-      const ymlArray = records
-        .map((record) => {
-          let rule: Dict = {}
+  if (records) {
+    const ymlArray = records
+      .map((record) => {
+        let rule: Dict = {}
 
-          // Memo: どの値もStringが入ってくる想定
-          const expected = record.get('expected')
-          const pattern = record.get('pattern')
-          const prh = record.get('prh')
-          const specFrom = record.get('spec:from')
-          const specTo = record.get('spec:to')
+        // Memo: どの値もStringが入ってくる想定
+        const expected = record.get('expected')
+        const pattern = record.get('pattern')
+        const prh = record.get('prh')
+        const specFrom = record.get('spec:from')
+        const specTo = record.get('spec:to')
 
-          if (typeof expected === 'string') {
-            rule = { ...rule, expected: expected }
-          }
-          if (typeof pattern === 'string') {
-            rule = { ...rule, pattern: pattern.split(',') }
-          }
-          if (typeof prh === 'string') {
-            rule = { ...rule, prh: prh }
-          }
-          if (typeof specFrom === 'string' && typeof specTo === 'string') {
-            // Memo: 必ずどちらも同数の値が入ることを前提としている
-            const specFromArray = specFrom.split(',')
-            const specToArray = specTo.split(',')
-            const specsArray = specFromArray.map((item, index) => {
-              return {
-                from: item,
-                to: specToArray[index],
-              }
-            })
-            rule = { ...rule, specs: specsArray }
-          }
-          return rule
-        })
-        .filter((dict) => {
-          return Object.keys(dict).length
-        })
-
-      const yamlString = yaml.dump({ rules: ymlArray })
-      fs.writeFile(DIST_PATH_NAME, yamlString, 'utf8', (err: any) => {
-        if (err) {
-          console.error(err.message)
-          process.exit(1)
+        if (typeof expected === 'string') {
+          rule = { ...rule, expected: expected }
         }
-        console.log(`データ出力完了しました。`)
+        if (typeof pattern === 'string') {
+          rule = { ...rule, pattern: pattern.split(',') }
+        }
+        if (typeof prh === 'string') {
+          rule = { ...rule, prh: prh }
+        }
+        if (typeof specFrom === 'string' && typeof specTo === 'string') {
+          // Memo: 必ずどちらも同数の値が入ることを前提としている
+          const specFromArray = specFrom.split(',')
+          const specToArray = specTo.split(',')
+          const specsArray = specFromArray.map((item, index) => {
+            return {
+              from: item,
+              to: specToArray[index],
+            }
+          })
+          rule = { ...rule, specs: specsArray }
+        }
+        return rule
       })
-    } else {
-      console.warn(`出力するデータがありません。`)
-    }
-  })
+      .filter((dict) => {
+        return Object.keys(dict).length
+      })
+
+    const yamlString = yaml.dump({ rules: ymlArray })
+    fs.writeFile(DIST_PATH_NAME, yamlString, 'utf8', (err: any) => {
+      if (err) {
+        console.error(err.message)
+        process.exit(1)
+      }
+      console.log(`データ出力完了しました。`)
+    })
+  } else {
+    console.warn(`出力するデータがありません。`)
+  }
+  };
+
+  main();


### PR DESCRIPTION
## 課題・背景

Airtable APIのレコード取得上限の100件よりもルールが多くなり、一部のルールが取得できなくなっていたので、修正したい。
https://support.airtable.com/docs/api-record-limits

<!--
e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
- 〇〇を〇〇したい
-->

## やったこと

- `records`取得部分のコードを修正

<!--
e.g.
- ルールの追加
-->

## やらなかったこと

- それ以外のコードの修正

<!--
e.g.
- 重複ルールの削除
-->

## 動作確認

- GitHub Actionsでbranchに`fix-airtable-records-limit`を指定して、ルールを全件取得できていることを確認済み。

### 正しいと判定される想定の文章

<!-- 
e.g.
ください。
-->

### 誤りと判定される想定の文章

<!-- 
e.g.
下さい。
-->
