### PR TITLE
fix: 「マスター」のルールを修正

### DIFF
--- a/dict/prh-idiomatic-usage.yml
+++ b/dict/prh-idiomatic-usage.yml
@@ -705,7 +705,7 @@ rules:
         to: ポリシー
   - expected: マスターデータ
     pattern:
-      - /(?<!部署|役職|［.*］|カスタム|システム標準|SmartHR ?|ドメイン)マスタ(?!ー)(データ)?/
+      - /(?<!［)(?<!部署|役職|カスタム|システム標準|SmartHR ?|ドメイン)(?<!］)マスタ(?!ー)(データ)?/
     prh: >-
       マスターデータの総称は「マスターデータ」、総称以外は「◯◯マスター」と表記するhttps://smarthr.design/products/contents/idiomatic-usage/usage/
     specs:
@@ -954,7 +954,7 @@ rules:
         to: ユーザビリティ
   - expected: マスターデータ
     pattern:
-      - /(?<!部署|役職|［.*］|カスタム|システム標準|SmartHR ?|ドメイン)マスター(?!データ)/
+      - /(?<!［)(?<!部署|役職|カスタム|システム標準|SmartHR ?|ドメイン)(?<!］)マスター(?!データ)/
     prh: >-
       マスターデータの総称は「マスターデータ」、総称以外は「◯◯マスター」と表記するhttps://smarthr.design/products/contents/idiomatic-usage/usage/
     specs:

--- a/dict/prh-idiomatic-usage.yml
+++ b/dict/prh-idiomatic-usage.yml
@@ -954,7 +954,7 @@ rules:
         to: ユーザビリティ
   - expected: マスターデータ
     pattern:
-      - /(?<!［)(?<!部署|役職|カスタム|システム標準|SmartHR ?|ドメイン)(?<!］)マスター(?!データ)/
+      - /(?<!部署|役職|］|カスタム|システム標準|SmartHR ?|ドメイン)マスター(?!データ)/
     prh: >-
       マスターデータの総称は「マスターデータ」、総称以外は「◯◯マスター」と表記するhttps://smarthr.design/products/contents/idiomatic-usage/usage/
     specs:

--- a/dict/prh-idiomatic-usage.yml
+++ b/dict/prh-idiomatic-usage.yml
@@ -705,7 +705,7 @@ rules:
         to: ポリシー
   - expected: マスターデータ
     pattern:
-      - /(?<!［)(?<!部署|役職|カスタム|システム標準|SmartHR ?|ドメイン)(?<!］)マスタ(?!ー)(データ)?/
+      - /(?<!部署|役職|］|カスタム|システム標準|SmartHR ?|ドメイン)マスタ(?!ー)(データ)?/
     prh: >-
       マスターデータの総称は「マスターデータ」、総称以外は「◯◯マスター」と表記するhttps://smarthr.design/products/contents/idiomatic-usage/usage/
     specs:


### PR DESCRIPTION
## 課題・背景

以前対応した「マスター」の誤検知が直っていなかったので修正したい。

https://kufuinc.slack.com/archives/C01RP2QJT2B/p1672964973922399?thread_ts=1670549531.752129&cid=C01RP2QJT2B

<!--
e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
- 〇〇を〇〇したい
-->

## やったこと

rubyの正規表現エンジンでも誤検知が起こらないように正規表現を書き換えた。

<!--
e.g.
- ルールの追加
-->

## やらなかったこと

<!--
e.g.
- 重複ルールの削除
-->

## 動作確認

### 正しいと判定される想定の文章

<!-- 
e.g.
ください。
-->

### 誤りと判定される想定の文章

<!-- 
e.g.
下さい。
-->
