### PR TITLE
fix: 「ならび」の誤検知を修正

### DIFF
--- a/dict/prh-idiomatic-usage.yml
+++ b/dict/prh-idiomatic-usage.yml
@@ -971,12 +971,16 @@ rules:
         to: ユーザビリティ
       - from: ユーザビリティー
         to: ユーザビリティ
-  - expected: 並び
+  - expected: 並$1
     pattern:
-      - /[横|縦]?(ならび)順?/
+      - /なら([びぶべ])(?!に)/
     specs:
-      - from: ならび
-        to: 並び
+      - from: 横ならび
+        to: 横並び
+      - from: 縦ならび
+        to: 縦並び
+      - from: ならび順
+        to: 並び順
   - expected: マスターデータ
     pattern:
       - /(?<!部署|役職|］|カスタム|システム標準|SmartHR ?|ドメイン)マスター(?!データ)/


### PR DESCRIPTION
## 課題・背景

「ならび→並び」のルールが「並びに→ならびに」のルールとコンフリクトしていたので、修正。

<!--
e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
- 〇〇を〇〇したい
-->

## やったこと

「ならびに」を検知しないよう修正した。

<!--
e.g.
- ルールの追加
-->

## やらなかったこと

<!--
e.g.
- 重複ルールの削除
-->

## 動作確認

### 正しいと判定される想定の文章

<!-- 
e.g.
ください。
-->

### 誤りと判定される想定の文章

<!-- 
e.g.
下さい。
-->
