### PR TITLE
fix: 「横並びに」「縦並びに」を誤検知しないように修正

### DIFF
--- a/dict/prh-idiomatic-usage.yml
+++ b/dict/prh-idiomatic-usage.yml
@@ -155,7 +155,7 @@ rules:
         to: 住所などを入力
   - expected: ならびに
     pattern:
-      - 並びに
+      - /(?<![横縦])並びに/
     prh: >-
       平仮名にしたほうが読みやすい漢字は平仮名にする
       https://smarthr.design/products/contents/writing-style/


### PR DESCRIPTION
## 課題・背景
↓に対応もれがあったので追加で修正しました 🙏 
https://kufuinc.slack.com/archives/C01RP2QJT2B/p1673927110936349?thread_ts=1673920541.442159&cid=C01RP2QJT2B

<!--
e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
- 〇〇を〇〇したい
-->

## やったこと

「横並びに」「縦並びに」を「ならびに」で誤検知しないよう修正。

<!--
e.g.
- ルールの追加
-->

## やらなかったこと

「横ならびに」「縦ならびに」が検知されない問題は別チケ対応。
https://smarthr.atlassian.net/browse/TEXTLINT-111
<!--
e.g.
- 重複ルールの削除
-->

## 動作確認

### 正しいと判定される想定の文章

<!-- 
e.g.
ください。
-->

### 誤りと判定される想定の文章

<!-- 
e.g.
下さい。
-->
