### PR TITLE
fix: 「一人ひとり」「一人称」の誤検知を修正

### DIFF
--- a/dict/prh-idiomatic-usage.yml
+++ b/dict/prh-idiomatic-usage.yml
@@ -633,7 +633,7 @@ rules:
         to: 1つ
   - expected: 1人
     pattern:
-      - /一人|ひとり/
+      - /(?<!一人)(一人|ひとり)(?!ひとり|称)/
     prh: >-
       数字は半角の算用数字で表記する
       https://smarthr.design/products/contents/idiomatic-usage/usage/


### PR DESCRIPTION
## 課題・背景
https://smarthr.atlassian.net/browse/TEXTLINT-113
<!--
e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
- 〇〇を〇〇したい
-->

## やったこと

- 「一人ひとり」「一人称」を「1人1人」「1人称」に誤検知しないよう修正

<!--
e.g.
- ルールの追加
-->

## やらなかったこと

<!--
e.g.
- 重複ルールの削除
-->

## 動作確認

### 正しいと判定される想定の文章

<!-- 
e.g.
ください。
-->

### 誤りと判定される想定の文章

<!-- 
e.g.
下さい。
-->
