### PR TITLE
fix: 「ひとり親」の誤検知を修正

### DIFF
--- a/dict/prh-idiomatic-usage.yml
+++ b/dict/prh-idiomatic-usage.yml
@@ -633,7 +633,7 @@ rules:
         to: 1つ
   - expected: 1人
     pattern:
-      - /(?<!一人)(一人|ひとり)(?!ひとり|称)/
+      - /(?<!一人)(一人|ひとり)(?!ひとり|称|親)/
     prh: >-
       数字は半角の算用数字で表記する
       https://smarthr.design/products/contents/idiomatic-usage/usage/


### PR DESCRIPTION
## 課題・背景

- 「ひとり親」が「1人親」に誤検知されていたため、修正する

<!--
e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
- 〇〇を〇〇したい
-->

## やったこと

- 「ひとり」の正規表現を修正

<!--
e.g.
- ルールの追加
-->

## やらなかったこと

<!--
e.g.
- 重複ルールの削除
-->

## 動作確認

### 正しいと判定される想定の文章

<!-- 
e.g.
ください。
-->

### 誤りと判定される想定の文章

<!-- 
e.g.
下さい。
-->
