### PR TITLE
fix: PCの誤検知を修正

### DIFF
--- a/dict/prh-idiomatic-usage.yml
+++ b/dict/prh-idiomatic-usage.yml
@@ -1059,8 +1059,7 @@ rules:
         to: 通勤経路検索機能はオプション機能です
   - expected: パソコン
     pattern:
-      - PC
-      - パーソナルコンピューター
+      - /(?<![a-zA-Z])PC(?![a-zA-Z])/
     prh: >-
       「パソコン」と表記し、「PC」の使用は控える
       https://smarthr.design/products/contents/idiomatic-usage/usage/#recw4wmIL3QqcKmoc-0

--- a/dict/prh-idiomatic-usage.yml
+++ b/dict/prh-idiomatic-usage.yml
@@ -1066,6 +1066,8 @@ rules:
     specs:
       - from: PCを使用します
         to: パソコンを使用します
+      - from: HOGEPCFOO
+        to: HOGEPCFOO
   - expected: 画面
     pattern:
       - /モーダルウィンドウ|モーダルダイアログ|ウィンドウ|ダイアログ|モーダル/


### PR DESCRIPTION
## 課題・背景

base64エンコード後の画像データに含まれる「PC」の文字列を誤検知していたため、修正したい。

<!--
e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
- 〇〇を〇〇したい
-->

## やったこと

- PCの前後にアルファベットがある場合は、検知しないようにルールを修正
- 用字用語のNG例にない「パーソナルコンピューター」のルールを削除

<!--
e.g.
- ルールの追加
-->

## やらなかったこと

<!--
e.g.
- 重複ルールの削除
-->

## 動作確認

### 正しいと判定される想定の文章

<!-- 
e.g.
ください。
-->

### 誤りと判定される想定の文章

<!-- 
e.g.
下さい。
-->
