### PR TITLE
fix: 「解す」の誤検知を修正

### DIFF
--- a/dict/prh-idiomatic-usage.yml
+++ b/dict/prh-idiomatic-usage.yml
@@ -1280,7 +1280,7 @@ rules:
         to: 改めて
   - expected: ほぐ$1
     pattern:
-      - /(?<![正分理])解([さしすせそ])/
+      - /(?<![正分理読])解([さしすせそ])/
     prh: >-
       平仮名にしたほうが読みやすい漢字は平仮名にする
       https://smarthr.design/products/writing/idiomatic-usage/usage/

--- a/dict/prh-idiomatic-usage.yml
+++ b/dict/prh-idiomatic-usage.yml
@@ -1295,6 +1295,14 @@ rules:
         to: ほぐせば
       - from: 解そう
         to: ほぐそう
+      - from: 正解
+        to: 正解
+      - from: 分解
+        to: 分解
+      - from: 理解
+        to: 理解
+      - from: 読解
+        to: 読解
   - expected: 手引き
     pattern:
       - /手引(?!き)/


### PR DESCRIPTION
## 課題・背景

「解す→ほぐす」のルールが「読解する」で誤検知していたため、修正したい。
https://kufuinc.slack.com/archives/C018J0A6DCH/p1680234560272669

<!--
e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
- 〇〇を〇〇したい
-->

## やったこと

「読解する」を検知しないようルールを修正した。

<!--
e.g.
- ルールの追加
-->

## やらなかったこと

<!--
e.g.
- 重複ルールの削除
-->

## 動作確認

### 正しいと判定される想定の文章

<!-- 
e.g.
ください。
-->

### 誤りと判定される想定の文章

<!-- 
e.g.
下さい。
-->
