### PR TITLE
feat: 「押下する」を禁止する

### DIFF
--- a/dict/prh-idiomatic-usage.yml
+++ b/dict/prh-idiomatic-usage.yml
@@ -1467,3 +1467,51 @@ rules:
     specs:
       - from: シュミレーション
         to: シミュレーション
+  - expected: 押せ
+    pattern:
+      - 押下でき
+    prh: >-
+      プロダクト内でユーザーにボタン押下を促す際は「押す」を使用する https://smarthr.design/products/contents/idiomatic-usage/usage/#recVAeJr4Di3vQHeA-0
+    specs:
+      - from: ボタンを押せる,ボタンを押せない
+        to: ボタンを押下できる,ボタンを押下できない
+  - expected: 押す
+    pattern:
+      - 押下する
+    prh: >-
+      プロダクト内でユーザーにボタン押下を促す際は「押す」を使用する https://smarthr.design/products/contents/idiomatic-usage/usage/#recVAeJr4Di3vQHeA-0
+    specs:
+      - from: ボタンを押す
+        to: ボタンを押下する
+  - expected: 押さない
+    pattern:
+      - 押下しない
+    prh: >-
+      プロダクト内でユーザーにボタン押下を促す際は「押す」を使用する https://smarthr.design/products/contents/idiomatic-usage/usage/#recVAeJr4Di3vQHeA-0
+    specs:
+      - from: ボタンを押さない
+        to: ボタンを押下しない
+  - expected: 押せば
+    pattern:
+      - 押下すれば
+    prh: >-
+      プロダクト内でユーザーにボタン押下を促す際は「押す」を使用する https://smarthr.design/products/contents/idiomatic-usage/usage/#recVAeJr4Di3vQHeA-0
+    specs:
+      - from: ボタンを押せば
+        to: ボタンを押下すれば
+  - expected: 押します
+    pattern:
+      - 押下します
+    prh: >-
+      プロダクト内でユーザーにボタン押下を促す際は「押す」を使用する https://smarthr.design/products/contents/idiomatic-usage/usage/#recVAeJr4Di3vQHeA-0
+    specs:
+      - from: ボタンを押します
+        to: ボタンを押下します
+  - expected: 押した
+    pattern:
+      - 押下した
+    prh: >-
+      プロダクト内でユーザーにボタン押下を促す際は「押す」を使用する https://smarthr.design/products/contents/idiomatic-usage/usage/#recVAeJr4Di3vQHeA-0
+    specs:
+      - from: ボタンを押した
+        to: ボタンを押下した

--- a/dict/prh-idiomatic-usage.yml
+++ b/dict/prh-idiomatic-usage.yml
@@ -1473,45 +1473,45 @@ rules:
     prh: >-
       プロダクト内でユーザーにボタン押下を促す際は「押す」を使用する https://smarthr.design/products/contents/idiomatic-usage/usage/#recVAeJr4Di3vQHeA-0
     specs:
-      - from: ボタンを押せる,ボタンを押せない
-        to: ボタンを押下できる,ボタンを押下できない
+      - from: ボタンを押下できる,ボタンを押下できない
+        to: ボタンを押せる,ボタンを押せない
   - expected: 押す
     pattern:
       - 押下する
     prh: >-
       プロダクト内でユーザーにボタン押下を促す際は「押す」を使用する https://smarthr.design/products/contents/idiomatic-usage/usage/#recVAeJr4Di3vQHeA-0
     specs:
-      - from: ボタンを押す
-        to: ボタンを押下する
+      - from: ボタンを押下する
+        to: ボタンを押す
   - expected: 押さない
     pattern:
       - 押下しない
     prh: >-
       プロダクト内でユーザーにボタン押下を促す際は「押す」を使用する https://smarthr.design/products/contents/idiomatic-usage/usage/#recVAeJr4Di3vQHeA-0
     specs:
-      - from: ボタンを押さない
-        to: ボタンを押下しない
+      - from: ボタンを押下しない
+        to: ボタンを押さない
   - expected: 押せば
     pattern:
       - 押下すれば
     prh: >-
       プロダクト内でユーザーにボタン押下を促す際は「押す」を使用する https://smarthr.design/products/contents/idiomatic-usage/usage/#recVAeJr4Di3vQHeA-0
     specs:
-      - from: ボタンを押せば
-        to: ボタンを押下すれば
+      - from: ボタンを押下すれば
+        to: ボタンを押せば
   - expected: 押します
     pattern:
       - 押下します
     prh: >-
       プロダクト内でユーザーにボタン押下を促す際は「押す」を使用する https://smarthr.design/products/contents/idiomatic-usage/usage/#recVAeJr4Di3vQHeA-0
     specs:
-      - from: ボタンを押します
-        to: ボタンを押下します
+      - from: ボタンを押下します
+        to: ボタンを押します
   - expected: 押した
     pattern:
       - 押下した
     prh: >-
       プロダクト内でユーザーにボタン押下を促す際は「押す」を使用する https://smarthr.design/products/contents/idiomatic-usage/usage/#recVAeJr4Di3vQHeA-0
     specs:
-      - from: ボタンを押した
-        to: ボタンを押下した
+      - from: ボタンを押下した
+        to: ボタンを押した


### PR DESCRIPTION
## 課題・背景
ボタンを押下する操作に対する「押下する」の表現がガイドラインで禁止されているので、textlintで検出できるようにしたい。
https://smarthr.design/products/contents/idiomatic-usage/usage/#recVAeJr4Di3vQHeA-0
> アプリケーション上でボタンを押下する操作は「押す」と表現し、「クリック」「タップ」「押下」の使用は控える

依頼元：https://kufuinc.slack.com/archives/CJX59GJFR/p1718155653977809
Jira Ticket：https://smarthr.atlassian.net/browse/SD-808

## やったこと
以下のようにBefore&Afterのバリュエーションが多く、正規表現での置換は困難。

- 押下する → 押す
- 押下します → 押します
- 押下しない → 押さない
- 押下できる/できない → 押せる/押せない
- 押下すれば → 押せば
- 押下したら → 押したら

置換それぞれを1つずつルールとして（＝Airtableの行として）定義する方針もありとのことで、その方針とする。 https://kufuinc.slack.com/archives/CJX59GJFR/p1718679042992979?thread_ts=1718155653.977809&cid=CJX59GJFR

追加したレコード
https://airtable.com/appgRe6XLv39vNM0C/tblbDiUxsSKGMXn0j/viwmiJfdPnu1duaMv/recUSfsOANhHlu05c?blocks=hide https://airtable.com/appgRe6XLv39vNM0C/tblbDiUxsSKGMXn0j/viwmiJfdPnu1duaMv/rec2SC0xL314Ljvyt?blocks=hide https://airtable.com/appgRe6XLv39vNM0C/tblbDiUxsSKGMXn0j/viwmiJfdPnu1duaMv/rec17SqgG6HDHtWv5?blocks=hide https://airtable.com/appgRe6XLv39vNM0C/tblbDiUxsSKGMXn0j/viwmiJfdPnu1duaMv/recJZLaVcVdhG8naS?blocks=hide https://airtable.com/appgRe6XLv39vNM0C/tblbDiUxsSKGMXn0j/viwmiJfdPnu1duaMv/recEDhFafdO3fBZfS?blocks=hide https://airtable.com/appgRe6XLv39vNM0C/tblbDiUxsSKGMXn0j/viwmiJfdPnu1duaMv/rec9ra7g2mprHoYzu?blocks=hide

## やらなかったこと
クリック」や「タップ」も禁止されているが、これらはURLを押下する操作に対して有効な表現なので、検出対象としない。

## 動作確認

### 正しいと判定される想定の文章
ボタンを押せる
ボタンを押せない
ボタンを押す
ボタンを押さない
ボタンを押せば
ボタンを押します
ボタンを押した

### 誤りと判定される想定の文章
ボタンを押下できる
ボタンを押下できない
ボタンを押下する
ボタンを押下しない
ボタンを押下すれば
ボタンを押下します
ボタンを押下した
