### PR TITLE
fix: pnpm publish時にブランチを指定

### DIFF
--- a/.github/workflows/publishRelease.yml
+++ b/.github/workflows/publishRelease.yml
@@ -31,11 +31,11 @@ jobs:
         if: ${{ env.IS_PRERELEASE == 'false' }}
       - run: pnpm release --prerelease
         if: ${{ env.IS_PRERELEASE == 'true' }}
-      - run: pnpm publish
+      - run: pnpm publish --no-git-checks
         if: ${{ env.IS_PRERELEASE == 'false' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.KUFU_NPM_RELEASE_TOKEN }}
-      - run: pnpm publish --tag prerelease
+      - run: pnpm publish --tag prerelease --no-git-checks
         if: ${{ env.IS_PRERELEASE == 'true' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.KUFU_NPM_RELEASE_TOKEN }}

--- a/.github/workflows/publishRelease.yml
+++ b/.github/workflows/publishRelease.yml
@@ -31,11 +31,11 @@ jobs:
         if: ${{ env.IS_PRERELEASE == 'false' }}
       - run: pnpm release --prerelease
         if: ${{ env.IS_PRERELEASE == 'true' }}
-      - run: pnpm publish --no-git-checks
+      - run: pnpm publish --publish-branch release-candidate
         if: ${{ env.IS_PRERELEASE == 'false' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.KUFU_NPM_RELEASE_TOKEN }}
-      - run: pnpm publish --tag prerelease --no-git-checks
+      - run: pnpm publish --tag prerelease --publish-branch release-candidate
         if: ${{ env.IS_PRERELEASE == 'true' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.KUFU_NPM_RELEASE_TOKEN }}


### PR DESCRIPTION
## 課題・背景
- ~GitHub Actionsで `pnpm publish` を実行する際、`--no-git-checks` を指定しないと、npmへの公開に失敗する~
    - ~publishするブランチがmain/master以外の場合は指定しないといけない~
- main/masterブランチ以外で `pnpm publish` を実行する際、ブランチを明示しないとエラーが発生する

<!--
e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
- 〇〇を〇〇したい
-->

## やったこと
- `pnpm publish` に `--publish-branch release-candidate` を追加
<!--
e.g.
- ルールの追加
-->
