### PR TITLE
feat: 「マスター」に関するルール追加

### DIFF
--- a/dict/prh-idiomatic-usage.yml
+++ b/dict/prh-idiomatic-usage.yml
@@ -874,7 +874,7 @@ rules:
   - expected: マスターデータ
     pattern:
       - >-
-        /(?<!部署|役職|雇用形態|等級|］|スキル|資格|研修|カスタム|システム標準|SmartHR
+        /(?<!部署|役職|雇用形態|等級|続柄|］|スキル|資格|研修|カスタム|システム標準|SmartHR
         ?|ドメイン)マスタ(?!ー)(データ)?/
     prh: >-
       マスターデータの総称は「マスターデータ」、総称以外は「◯◯マスター」と表記するhttps://smarthr.design/products/contents/idiomatic-usage/usage/
@@ -889,6 +889,8 @@ rules:
         to: 役職マスター
       - from: 雇用形態マスター
         to: 雇用形態マスター
+      - from: 続柄マスター
+        to: 続柄マスター        
       - from: SmartHRマスター
         to: SmartHRマスター
   - expected: マネージャー


### PR DESCRIPTION
## 課題・背景

「続柄マスター」が誤ってエラーと判定されてしまうので、修正したい。
「マスター => マスターデータ」というルールに、ひっかかってしまう。

## やったこと

- ルールの追加

## やらなかったこと

- 特になし

## 動作確認

### 正しいと判定される想定の文章

続柄マスターのコード変換は家族情報のみに適用されます

### 誤りと判定される想定の文章

略
