### PR TITLE
feat: 「マスター」に関するルールに評価記号マスターを追加

### DIFF
--- a/dict/prh-idiomatic-usage.yml
+++ b/dict/prh-idiomatic-usage.yml
@@ -874,7 +874,7 @@ rules:
   - expected: マスターデータ
     pattern:
       - >-
-        /(?<!部署|役職|雇用形態|等級|続柄|］|スキル|資格|研修|カスタム|システム標準|SmartHR
+        /(?<!部署|役職|雇用形態|等級|続柄|評価記号］|スキル|資格|研修|カスタム|システム標準|SmartHR
         ?|ドメイン)マスタ(?!ー)(データ)?/
     prh: >-
       マスターデータの総称は「マスターデータ」、総称以外は「◯◯マスター」と表記するhttps://smarthr.design/products/contents/idiomatic-usage/usage/
@@ -891,6 +891,8 @@ rules:
         to: 雇用形態マスター
       - from: 続柄マスター
         to: 続柄マスター
+      - from: 評価記号マスター
+        to: 評価記号マスター
       - from: SmartHRマスター
         to: SmartHRマスター
   - expected: マネージャー


### PR DESCRIPTION
## 課題・背景
人事評価機能で評価記号マスターがリリースされました。
[評価記号マスターを作成する｜SmartHR](https://support.smarthr.jp/ja/help/articles/0fb112b5-8a16-4c54-a117-870b30079d16/)

「評価記号マスター」が誤ってエラーと判定されてしまうため、エラーとならないよう修正したいです。
「マスター → マスターデータ」のルールに検知されてしまいます。

<!--
e.g.
- GitHub Issues URL
- JIRA ticket URL (For SmartHR internal developers)
- 〇〇を〇〇したい
-->

## やったこと
- ルールの追加

<!--
e.g.
- ルールの追加
-->

## やらなかったこと
- 特にありません

<!--
e.g.
- 重複ルールの削除
-->

## 動作確認

### 正しいと判定される想定の文章
評価記号マスターは、汎用テンプレートで使用できます。
<!-- 
e.g.
ください。
-->

### 誤りと判定される想定の文章
- 評価マスター
- 記号マスター
<!-- 
e.g.
下さい。
-->
