### PR TITLE
fix: 「前後で」を許容する

### DIFF
--- a/dict/prh-idiomatic-usage.yml
+++ b/dict/prh-idiomatic-usage.yml
@@ -274,7 +274,7 @@ rules:
         to: アクセシビリティ
   - expected: あとで
     pattern:
-      - /(?<![始了直])後で/
+      - /(?<![始了直前])後で/
     prh: >-
       平仮名にしたほうが読みやすい漢字は平仮名にする
       https://smarthr.design/products/contents/writing-style/
@@ -283,6 +283,8 @@ rules:
         to: あとでやります。
       - from: 評価開始後でも編集できます。
         to: 評価開始後でも編集できます。
+      - from: 30分前後で回答します。
+        to: 30分前後で回答します。
   - expected: したうえで
     pattern:
       - した上で


### PR DESCRIPTION
## 課題・背景

「前後で」が誤爆して「前あとで」になってしまうのを防止する

## やったこと

- `後で`の直前に「前」がきたらチェックしない
- テストの追加

## やらなかったこと

<!--
e.g.
- 重複ルールの削除
-->

## 動作確認

### 正しいと判定される想定の文章

30分前後で回答します。

### 誤りと判定される想定の文章

<!-- 
e.g.
下さい。
-->
