### PR TITLE
fix: 「誤解」が smarthr/prh-rules に検知されないようにしたい

### DIFF
--- a/dict/prh-idiomatic-usage.yml
+++ b/dict/prh-idiomatic-usage.yml
@@ -1314,7 +1314,7 @@ rules:
         to: 改めて
   - expected: ほぐ$1
     pattern:
-      - /(?<![正分理読])解([さしすせそ])/
+      - /(?<![正分理読誤])解([さしすせそ])/
     prh: >-
       平仮名にしたほうが読みやすい漢字は平仮名にする
       https://smarthr.design/products/contents/writing-style/
@@ -1337,6 +1337,8 @@ rules:
         to: 理解
       - from: 読解
         to: 読解
+      - from: 誤解
+        to: 誤解
   - expected: 手引き
     pattern:
       - /手引(?!き)/


### PR DESCRIPTION
## 課題・背景

リリースノートの文章で「誤解されやすい」という表現がtextlintにひっかかってしまった。
特に感じを開いたり、別表現にする必要のない表現のため、textlintの検出対象外にしたい。

## やったこと

「誤解」を検出しないように設定変更した

## やらなかったこと

なし

## 動作確認

### 正しいと判定される想定の文章

e.g.
誤解されやすい

### 誤りと判定される想定の文章

e.g.
解す

