### PR TITLE
chore: @types/node to v24.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@textlint/textlint-plugin-text": "^15.5.1",
     "@textlint/types": "^15.2.3",
     "@types/js-yaml": "^4.0.9",
-    "@types/node": "^22.19.7",
+    "@types/node": "^24.1.0",
     "fs": "^0.0.1-security",
     "husky": "^9.1.7",
     "prettier": "^3.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,7 +95,7 @@ importers:
     devDependencies:
       '@commitlint/cli':
         specifier: ^19.8.1
-        version: 19.8.1(@types/node@22.19.7)(typescript@5.9.2)
+        version: 19.8.1(@types/node@24.12.0)(typescript@5.9.2)
       '@commitlint/config-conventional':
         specifier: ^19.8.1
         version: 19.8.1
@@ -112,8 +112,8 @@ importers:
         specifier: ^4.0.9
         version: 4.0.9
       '@types/node':
-        specifier: ^22.19.7
-        version: 22.19.7
+        specifier: ^24.1.0
+        version: 24.12.0
       fs:
         specifier: ^0.0.1-security
         version: 0.0.1-security
@@ -131,13 +131,13 @@ importers:
         version: 15.5.1(hono@4.11.5)
       textlint-scripts:
         specifier: ^15.2.3
-        version: 15.5.1(ts-node@10.9.2(@types/node@22.19.7)(typescript@5.9.2))(typescript@5.9.2)
+        version: 15.5.1(ts-node@10.9.2(@types/node@24.12.0)(typescript@5.9.2))(typescript@5.9.2)
       textlint-tester:
         specifier: ^15.2.3
         version: 15.5.1
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.19.7)(typescript@5.9.2)
+        version: 10.9.2(@types/node@24.12.0)(typescript@5.9.2)
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
@@ -963,8 +963,8 @@ packages:
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
 
-  '@types/node@22.19.7':
-    resolution: {integrity: sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==}
+  '@types/node@24.12.0':
+    resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -3287,8 +3287,8 @@ packages:
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -4191,11 +4191,11 @@ snapshots:
       hashery: 1.4.0
       keyv: 5.6.0
 
-  '@commitlint/cli@19.8.1(@types/node@22.19.7)(typescript@5.9.2)':
+  '@commitlint/cli@19.8.1(@types/node@24.12.0)(typescript@5.9.2)':
     dependencies:
       '@commitlint/format': 19.8.1
       '@commitlint/lint': 19.8.1
-      '@commitlint/load': 19.8.1(@types/node@22.19.7)(typescript@5.9.2)
+      '@commitlint/load': 19.8.1(@types/node@24.12.0)(typescript@5.9.2)
       '@commitlint/read': 19.8.1
       '@commitlint/types': 19.8.1
       tinyexec: 1.0.1
@@ -4242,7 +4242,7 @@ snapshots:
       '@commitlint/rules': 19.8.1
       '@commitlint/types': 19.8.1
 
-  '@commitlint/load@19.8.1(@types/node@22.19.7)(typescript@5.9.2)':
+  '@commitlint/load@19.8.1(@types/node@24.12.0)(typescript@5.9.2)':
     dependencies:
       '@commitlint/config-validator': 19.8.1
       '@commitlint/execute-rule': 19.8.1
@@ -4250,7 +4250,7 @@ snapshots:
       '@commitlint/types': 19.8.1
       chalk: 5.3.0
       cosmiconfig: 9.0.0(typescript@5.9.2)
-      cosmiconfig-typescript-loader: 6.1.0(@types/node@22.19.7)(cosmiconfig@9.0.0(typescript@5.9.2))(typescript@5.9.2)
+      cosmiconfig-typescript-loader: 6.1.0(@types/node@24.12.0)(cosmiconfig@9.0.0(typescript@5.9.2))(typescript@5.9.2)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -4653,7 +4653,7 @@ snapshots:
 
   '@types/conventional-commits-parser@5.0.0':
     dependencies:
-      '@types/node': 22.19.7
+      '@types/node': 24.12.0
 
   '@types/js-yaml@4.0.9': {}
 
@@ -4663,9 +4663,9 @@ snapshots:
 
   '@types/minimist@1.2.5': {}
 
-  '@types/node@22.19.7':
+  '@types/node@24.12.0':
     dependencies:
-      undici-types: 6.21.0
+      undici-types: 7.16.0
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -5147,9 +5147,9 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@6.1.0(@types/node@22.19.7)(cosmiconfig@9.0.0(typescript@5.9.2))(typescript@5.9.2):
+  cosmiconfig-typescript-loader@6.1.0(@types/node@24.12.0)(cosmiconfig@9.0.0(typescript@5.9.2))(typescript@5.9.2):
     dependencies:
-      '@types/node': 22.19.7
+      '@types/node': 24.12.0
       cosmiconfig: 9.0.0(typescript@5.9.2)
       jiti: 2.4.1
       typescript: 5.9.2
@@ -7143,7 +7143,7 @@ snapshots:
       textlint-rule-helper: 2.3.1
       textlint-util-to-string: 3.3.4
 
-  textlint-scripts@15.5.1(ts-node@10.9.2(@types/node@22.19.7)(typescript@5.9.2))(typescript@5.9.2):
+  textlint-scripts@15.5.1(ts-node@10.9.2(@types/node@24.12.0)(typescript@5.9.2))(typescript@5.9.2):
     dependencies:
       '@babel/cli': 7.28.6(@babel/core@7.28.6)
       '@babel/core': 7.28.6
@@ -7157,7 +7157,7 @@ snapshots:
       pkg-to-readme: 3.0.1
       textlint-tester: 15.5.1
     optionalDependencies:
-      ts-node: 10.9.2(@types/node@22.19.7)(typescript@5.9.2)
+      ts-node: 10.9.2(@types/node@24.12.0)(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -7257,14 +7257,14 @@ snapshots:
 
   trough@1.0.5: {}
 
-  ts-node@10.9.2(@types/node@22.19.7)(typescript@5.9.2):
+  ts-node@10.9.2(@types/node@24.12.0)(typescript@5.9.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.19.7
+      '@types/node': 24.12.0
       acorn: 8.14.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -7348,7 +7348,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.0.2
 
-  undici-types@6.21.0: {}
+  undici-types@7.16.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 


### PR DESCRIPTION
## 課題・背景

https://github.com/kufu/textlint-rule-preset-smarthr/pull/723 で、Node.js v24 にしたので、types のバージョンも合わせる

## やったこと

@types/node の最新版へのアップデート

## やらなかったこと

<!--
e.g.
- 重複ルールの削除
-->

## 動作確認

### 正しいと判定される想定の文章

<!-- 
e.g.
ください。
-->

### 誤りと判定される想定の文章

<!-- 
e.g.
下さい。
-->
