### PR TITLE
chore: 同時にバージョンが上がる textlintパッケージを、renovateのtextlint familyグループに追加

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,10 +17,12 @@
         "groupName": "textlint family",
         "matchPackageNames": [
           "textlint",
+          "@textlint/kernel",
+          "@textlint/module-interop",
+          "@textlint/textlint-plugin-text",
           "@textlint/types",
           "textlint-scripts",
-          "textlint-tester",
-          "@textlint/module-interop"
+          "textlint-tester"
         ],
         "matchUpdateTypes": ["minor", "patch"],
         "automerge": true


### PR DESCRIPTION

## 課題・背景

`@textlint/kernel` と `@textlint/textlint-plugin-text` は`@textlint` スコープの公式パッケージで、他の textlintファミリーと同じ monorepo から同じタイミングでリリースされる。
しかし renovate の "textlint family"グループに含まれていなかったため、別々の PR が作成されていた。

## やったこと

- `@textlint/kernel` と `@textlint/textlint-plugin-text` を renovate の "textlint family" グループに追加

## やらなかったこと

🍐

## 動作確認

`npx --package renovate -c 'renovate-config-validator'` でエラーが出ないことを確認した