### PR TITLE
chore: `lib/`が欠落する問題に対処

### DIFF
--- a/.github/workflows/publishRelease.yml
+++ b/.github/workflows/publishRelease.yml
@@ -41,6 +41,11 @@ jobs:
         if: ${{ env.IS_PRERELEASE == 'false' }}
       - run: pnpm release --prerelease
         if: ${{ env.IS_PRERELEASE == 'true' }}
+        # .npmrc の ignore-scripts=true により publish 時の prepublishOnly が
+        # スキップされるため、ビルド成果物 lib/ を明示的に生成する
+      - run: pnpm build
+      - name: verify build artifacts
+        run: test -f lib/index.js
       - run: pnpm publish --publish-branch release-candidate
         if: ${{ env.IS_PRERELEASE == 'false' }}
       - run: pnpm publish --tag prerelease --publish-branch release-candidate


### PR DESCRIPTION
## 課題・背景

https://github.com/kufu/textlint-rule-preset-smarthr/pull/768 で、.npmrc に ignore-scripts=trueを追加を追加した。
これにより、リリース時の`prepublishOnly`が実行されなくなり、publishされたパッケージに`lib`以下のファイルが含まれなくなってしまった。

## やったこと

- publish時に明示的に`pnpm run build`を実行する
- ビルド生成物が存在するかをチェックする

## やらなかったこと

` ignore-scripts=true`を外すこと

## 動作確認

pnpm run build をして、`lib`以下が生成されること

