### PR TITLE
chore: pnpm.overrides を pnpm-workspace.yaml に移行する

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,30 +85,5 @@
   "author": "SmartHR textlint Team",
   "license": "MIT",
   "description": "SmartHRらしい文書を書くための、textlintルールプリセットを提供します。",
-  "packageManager": "pnpm@10.16.1+sha512.0e155aa2629db8672b49e8475da6226aa4bdea85fdcdfdc15350874946d4f3c91faaf64cbdc4a5d1ab8002f473d5c3fcedcd197989cf0390f9badd3c04678706",
-  "pnpm": {
-    "overrides": {
-      "@hono/node-server@<1.19.13": "1.19.14",
-      "@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3": ">=1.26.0",
-      "ajv@>=7.0.0-alpha.0 <8.18.0": "8.18.0",
-      "body-parser@>=2.2.0 <2.2.1": "2.2.2",
-      "brace-expansion@<1.1.13": "1.1.14",
-      "brace-expansion@>=2.0.0 <2.0.3": "2.0.3",
-      "diff@>=4.0.0 <4.0.4": "4.0.4",
-      "diff@>=6.0.0 <8.0.3": "8.0.4",
-      "flatted@<=3.4.1": "3.4.2",
-      "handlebars@>=4.0.0 <4.7.9": "4.7.9",
-      "hono@<4.12.16": "4.12.18",
-      "lodash@>=4.0.0 <=4.17.23": "4.18.1",
-      "minimatch@<3.1.4": "3.1.5",
-      "minimatch@>=5.0.0 <5.1.8": "5.1.9",
-      "minimatch@>=9.0.0 <9.0.7": "9.0.7",
-      "path-to-regexp@>=8.0.0 <8.4.0": "8.4.0",
-      "picomatch@<2.3.2": "2.3.2",
-      "qs@<6.14.1": "6.14.1",
-      "qs@>=6.7.0 <=6.14.1": "6.14.2",
-      "serialize-javascript@<7.0.5": "7.0.5",
-      "ip-address@<=10.1.0": "10.1.1"
-    }
-  }
+  "packageManager": "pnpm@10.16.1+sha512.0e155aa2629db8672b49e8475da6226aa4bdea85fdcdfdc15350874946d4f3c91faaf64cbdc4a5d1ab8002f473d5c3fcedcd197989cf0390f9badd3c04678706"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,26 @@
 minimumReleaseAge: 10800 # 7 days
 minimumReleaseAgeExclude:
-  # Renovate security update: hono@<4.12.16@4.12.18
-  - hono@<4.12.16@4.12.18
+  - hono@4.12.18
+
+overrides:
+  "@hono/node-server@<1.19.13": "1.19.14"
+  "@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3": ">=1.26.0"
+  "ajv@>=7.0.0-alpha.0 <8.18.0": "8.18.0"
+  "body-parser@>=2.2.0 <2.2.1": "2.2.2"
+  "brace-expansion@<1.1.13": "1.1.14"
+  "brace-expansion@>=2.0.0 <2.0.3": "2.0.3"
+  "diff@>=4.0.0 <4.0.4": "4.0.4"
+  "diff@>=6.0.0 <8.0.3": "8.0.4"
+  "flatted@<=3.4.1": "3.4.2"
+  "handlebars@>=4.0.0 <4.7.9": "4.7.9"
+  "hono@<4.12.16": "4.12.18"
+  "lodash@>=4.0.0 <=4.17.23": "4.18.1"
+  "minimatch@<3.1.4": "3.1.5"
+  "minimatch@>=5.0.0 <5.1.8": "5.1.9"
+  "minimatch@>=9.0.0 <9.0.7": "9.0.7"
+  "path-to-regexp@>=8.0.0 <8.4.0": "8.4.0"
+  "picomatch@<2.3.2": "2.3.2"
+  "qs@<6.14.1": "6.14.1"
+  "qs@>=6.7.0 <=6.14.1": "6.14.2"
+  "serialize-javascript@<7.0.5": "7.0.5"
+  "ip-address@<=10.1.0": "10.1.1"


### PR DESCRIPTION

## 課題・背景

pnpm v10 では package.json の pnpm フィールドが非推奨になったため、overrides を pnpm-workspace.yaml に移行する。

## やったこと

- overrides を pnpm-workspace.yaml に移行
- minimumReleaseAgeExclude の不正なフォーマットを修正

## やらなかったこと

<!--
e.g.
- 重複ルールの削除
-->

## 動作確認

### 正しいと判定される想定の文章

<!-- 
e.g.
ください。
-->

### 誤りと判定される想定の文章

<!-- 
e.g.
下さい。
-->
