### PR TITLE
chore: 全ワークフローでnpmライフサイクルスクリプトの実行を無効化

### DIFF
--- a/.github/workflows/closeReleaseCandidate.yml
+++ b/.github/workflows/closeReleaseCandidate.yml
@@ -5,6 +5,9 @@ on:
     types:
       - closed
 
+env:
+  NPM_CONFIG_IGNORE_SCRIPTS: 'true'
+
 jobs:
   close_release_candidate:
     if: contains(github.event.issue.labels.*.name, 'release candidate')

--- a/.github/workflows/publishRelease.yml
+++ b/.github/workflows/publishRelease.yml
@@ -11,6 +11,9 @@ permissions:
   issues: write
   pull-requests: write
 
+env:
+  NPM_CONFIG_IGNORE_SCRIPTS: 'true'
+
 jobs:
   publish_release:
     if: github.event.issue.state == 'open' && contains(github.event.issue.labels.*.name, 'release candidate') && github.event.label.name == 'approve release'

--- a/.github/workflows/startRelease.yml
+++ b/.github/workflows/startRelease.yml
@@ -12,6 +12,9 @@ on:
         required: true
         default: 'auto'
 
+env:
+  NPM_CONFIG_IGNORE_SCRIPTS: 'true'
+
 jobs:
   start_release:
     if: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
       - main
   pull_request:
 
+env:
+  NPM_CONFIG_IGNORE_SCRIPTS: 'true'
+
 jobs:
   build-publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/titleCheck.yml
+++ b/.github/workflows/titleCheck.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+env:
+  NPM_CONFIG_IGNORE_SCRIPTS: 'true'
+
 jobs:
   conventional_commits:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## やりたいこと

npm の pre/postinstall スクリプトが GitHub Actions ランナー内で実行されることを悪用したサプライチェーン攻撃への対策です。

新しい npm はこれらをデフォルトで無効化しますが、古い npm を pin しているワークフローでは依然として実行されます。ランナー内での任意コード実行の経路を塞ぐため、`.github/workflows/` 配下の**全ワークフロー**に workflow レベルで `NPM_CONFIG_IGNORE_SCRIPTS: 'true'` を設定します。

設定漏れのファイルが将来的な穴になるため、bot / リリース系・単純な `uses:` 呼び出しのみのワークフローも**例外なく**対象にしています。

なお本リポジトリは `.npmrc` に既に `ignore-scripts=true` があるため、pnpm に対しては重複した設定になります。それでも以下の理由で入れる価値があると判断しました。

- `publishRelease.yml` の `npm install -g npm@latest` のように npm を直接叩くステップや、リポジトリルート外の作業ディレクトリでは `.npmrc` が効かない場合がある
- 組織内の全リポジトリで同じ設定を横断的に入れており、`grep` で設定漏れを検出できる状態を保ちたい

## やったこと

全 5 ファイルの `jobs:` 直前に top-level ブロックを追加しました（**5 files changed, 15 insertions(+), 0 deletions(-)**）。差分は追加行のみで、整形・空白修正・バージョン更新は含みません。

```yaml
env:
  NPM_CONFIG_IGNORE_SCRIPTS: 'true'

jobs:
```

対象: `closeReleaseCandidate.yml` / `publishRelease.yml` / `startRelease.yml` / `test.yml` / `titleCheck.yml`

`'true'` はクォートしています。裸の `true` は YAML boolean になり Actions が受け付けません。job / step レベルの `env:`（`publishRelease.yml` の `CHANGELOG_PATH` など）は「既存 env」とみなさず、触っていません。

### リリースフローへの影響がないことの確認

`prepublishOnly: pnpm run --if-present build` がスキップされて `lib/` 未生成のまま publish される懸念を確認しましたが、**既に対処済み**でした。

- `.npmrc` に `ignore-scripts=true` があり、`publishRelease.yml` には `pnpm publish` の前に明示的な `- run: pnpm build` と `test -f lib/index.js` の成果物検証ステップが入っている
- したがって今回の env 追加で publish の挙動は変わらない

`test.yml` も `pnpm install` → `pnpm test` → `pnpm build` を明示実行しており、ライフサイクルスクリプトには依存していません。

### ローカル検証結果

- `grep -L NPM_CONFIG_IGNORE_SCRIPTS .github/workflows/*.y*ml` → 出力なし（全ファイルに設定あり）
- 各ファイルの出現回数・top-level `env:` の個数 → いずれも 1
- 全 5 ワークフローを YAML パースし、`env.NPM_CONFIG_IGNORE_SCRIPTS` が**文字列** `"true"`（boolean ではない）であること・`jobs` が壊れていないことを assert → OK
- actionlint はローカル未インストール、Docker デーモンも未起動のため**未実行**。GitHub 側のワークフロー構文チェックで確認します。

## レビューしてほしいこと

`.npmrc` と重複する設定を入れる判断について（上記「やりたいこと」の理由で入れています）。不要であれば `publishRelease.yml` だけ、あるいは全体を取り下げます。

## マージ後にやること

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
